### PR TITLE
Changed Leaderboard to use PriorityQueue

### DIFF
--- a/final_project/lib/objects/tree_object.dart
+++ b/final_project/lib/objects/tree_object.dart
@@ -1,12 +1,8 @@
-class TreeObject{
+class TreeObject implements Comparable<TreeObject> {
   TreeObject({required this.treeid});
   int treeid;
   int likes = 0;
   
-  int get_likes(){
-    return likes;
-  }
-
   void add_like(){
     likes ++;
   }
@@ -15,9 +11,10 @@ class TreeObject{
     likes --;
   }
 
-  int get_treeId(){
-    return treeid;
+  // Automatically adjusts order of TreeObjects
+  @override
+  int compareTo(TreeObject other) {
+    return other.likes.compareTo(likes);
   }
 
-  
 }

--- a/final_project/lib/objects/tree_object.dart
+++ b/final_project/lib/objects/tree_object.dart
@@ -2,13 +2,13 @@ class TreeObject implements Comparable<TreeObject> {
   TreeObject({required this.treeid});
   int treeid;
   int likes = 0;
-  
-  void add_like(){
-    likes ++;
+
+  void add_like() {
+    likes++;
   }
 
-  void remove_Like(){
-    likes --;
+  void remove_Like() {
+    likes--;
   }
 
   // Automatically adjusts order of TreeObjects
@@ -16,5 +16,4 @@ class TreeObject implements Comparable<TreeObject> {
   int compareTo(TreeObject other) {
     return other.likes.compareTo(likes);
   }
-
 }

--- a/final_project/lib/pages/body/leaderboard.dart
+++ b/final_project/lib/pages/body/leaderboard.dart
@@ -1,4 +1,4 @@
-import 'dart:collection';
+import "package:collection/collection.dart";
 
 import 'package:final_project/api/tree.dart';
 import 'package:final_project/app_state.dart';
@@ -11,170 +11,8 @@ import 'package:provider/provider.dart';
 
 class Leaderboard extends StatefulWidget {
   Leaderboard({required this.trees, required this.userTrees});
-
   final List<TreeObject> trees;
   final bool userTrees;
-
-  List<TreeObject> topTenTrees = [];
-
-  
-
-  
-
-  
-
-  bool inList(TreeObject tree, List list){
-    for(var item in list){
-      if(item.get_treeId == tree.get_treeId){
-        return true;
-      }
-    }
-    return false;
-  }
-
-  void getTopTen(){
-    int max = 0;
-    int second = 0;
-    int third = 0;
-    int fourth = 0;
-    int fifth = 0;
-    int sixth = 0;
-    int seventh = 0;
-    int eighth = 0;
-    int ninth = 0;
-    int tenth = 0;
-
-    if(trees.length > 0){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[0].remove_Like();
-      max = topTenTrees[0].get_likes();
-      for(var tree in trees){
-        if(tree.get_likes() > max){
-          topTenTrees[0] = tree;
-          max = tree.get_likes();
-        }
-        
-      }
-      
-      
-    }
-
-    if(trees.length > 1){
-      topTenTrees.add(TreeObject(treeid: 200000000));
-      topTenTrees[1].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= max) 
-        & (tree.get_likes() >= second) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[1] = tree;
-          second = tree.get_likes();
-        }
-      }
-    }
-
-    if(trees.length > 2){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[2].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= second) 
-        & (tree.get_likes() >= third) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[2] = tree;
-          third = tree.get_likes();
-        }
-      }
-    }
-    if(trees.length > 3){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[3].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= third) 
-        & (tree.get_likes() >= fourth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[3] = tree;
-          fourth = tree.get_likes();
-        }
-      }
-    }
-    if(trees.length > 4){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[4].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= fourth) 
-        & (tree.get_likes() >= fifth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[4] = tree;
-          fifth = tree.get_likes();
-        }
-      }
-    }
-
-
-    if(trees.length > 5){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[5].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= fifth) 
-        & (tree.get_likes() >= sixth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[5] = tree;
-          sixth = tree.get_likes();
-        }
-      }
-    }
-
-    if(trees.length > 6){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[6].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= sixth) 
-        & (tree.get_likes() >= seventh) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[6] = tree;
-          seventh = tree.get_likes();
-        }
-      }
-    }
-
-    if(trees.length > 7){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[7].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= seventh) 
-        & (tree.get_likes() >= eighth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[7] = tree;
-          eighth = tree.get_likes();
-        }
-      }
-    }
-
-    if(trees.length > 8){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[8].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= eighth) 
-        & (tree.get_likes() >= ninth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[8] = tree;
-          ninth = tree.get_likes();
-        }
-      }
-    }
-
-    if(trees.length > 9){
-      topTenTrees.add(TreeObject(treeid: 20000000));
-      topTenTrees[9].remove_Like();
-      for(var tree in trees){
-        if((tree.get_likes() <= ninth) 
-        & (tree.get_likes() >= tenth) 
-        & (inList(tree, topTenTrees) == false)){
-          topTenTrees[9] = tree;
-          tenth = tree.get_likes();
-        }
-      }
-    }
-    }
 
   @override
   State<Leaderboard> createState() => _LeaderboardState();
@@ -182,43 +20,64 @@ class Leaderboard extends StatefulWidget {
 
 class _LeaderboardState extends State<Leaderboard> {
   late Future<Tree> futureTree;
+  PriorityQueue<TreeObject> treeQueue = PriorityQueue();
+
+  List<TreeObject> topTenTrees = [];
   
-  
+  // TEMP TO SHOW CORRECT ORDERING:
+  List<TreeObject> likeList = [TreeObject(treeid: 100000)
+    , TreeObject(treeid: 100001)
+    , TreeObject(treeid: 100002)
+    ];
 
   @override
   Widget build(BuildContext context) {
-    var appState = context.read<ApplicationState>();
-    if(!appState.loggedIn){
-      return Container(
-        child: Text('Log in to See Our Top Trees')
-      );
+    // TEMP TO SHOW CORRECT ORDERING (delete when likes fully work):
+    // ----------------------------------------------
+    for (int i = 0; i < 3; i++) {
+      likeList[i].likes = 10 + i;
+    }
+    treeQueue.addAll(likeList);
+    // ----------------------------------------------
+
+
+    treeQueue.addAll(widget.trees);
+
+
+    for (int i = 0; i < 10 && treeQueue.isNotEmpty; i++) {
+      topTenTrees.add(treeQueue.removeFirst());
     }
 
-    if(!widget.userTrees){
-      widget.getTopTen();
-    }
+    // var appState = context.read<ApplicationState>();
+    // if(!appState.loggedIn){
+    //   return Container(
+    //     child: Text('Log in to See Our Top Trees')
+    //   );
+    // }
+
+    // if(!widget.userTrees){
+    //   widget.getTopTen();
+    // }
+
     int rank = 0;
-   
+
     return ListView(
           padding: const EdgeInsets.symmetric(vertical: 8.0),
           children: 
-          
-          widget.topTenTrees.map((item) {
-          //var futureTree = fetchTree(item.get_treeId());
+          topTenTrees.map((item) {
             rank++;
-    
+          //var futureTree = fetchTree(item.get_treeId());
             return ListTile(
               leading: CircleAvatar(
-                child: Text(rank.toString()),
                 backgroundColor: const Color.fromARGB(255, 5, 87, 47),
-                
+                child: Text(rank.toString()),
               ),
-              title: Text("Tree #" + item.get_treeId().toString()),
-              trailing: Text(item.get_likes().toString()),
+              title: Text("Tree #" + item.treeid.toString()),
+              trailing: Text(item.likes.toString()),
               onTap: () async {
           await Navigator.of(context).push(
             MaterialPageRoute(
-              builder: (context) => TreeInfo(treeid: item.get_treeId(),
+              builder: (context) => TreeInfo(treeid: item.treeid,
                 
               ),
             ),

--- a/final_project/lib/pages/body/leaderboard.dart
+++ b/final_project/lib/pages/body/leaderboard.dart
@@ -8,7 +8,6 @@ import 'package:final_project/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
-
 class Leaderboard extends StatefulWidget {
   Leaderboard({required this.trees, required this.userTrees});
   final List<TreeObject> trees;
@@ -23,12 +22,14 @@ class _LeaderboardState extends State<Leaderboard> {
   PriorityQueue<TreeObject> treeQueue = PriorityQueue();
 
   List<TreeObject> topTenTrees = [];
-  
-  // TEMP TO SHOW CORRECT ORDERING:
-  List<TreeObject> likeList = [TreeObject(treeid: 100000)
-    , TreeObject(treeid: 100001)
-    , TreeObject(treeid: 100002)
-    ];
+
+  // ----------------------------------------------
+  List<TreeObject> likeList = [
+    TreeObject(treeid: 100000),
+    TreeObject(treeid: 100001),
+    TreeObject(treeid: 100002)
+  ];
+  // ----------------------------------------------
 
   @override
   Widget build(BuildContext context) {
@@ -40,9 +41,7 @@ class _LeaderboardState extends State<Leaderboard> {
     treeQueue.addAll(likeList);
     // ----------------------------------------------
 
-
     treeQueue.addAll(widget.trees);
-
 
     for (int i = 0; i < 10 && treeQueue.isNotEmpty; i++) {
       topTenTrees.add(treeQueue.removeFirst());
@@ -62,37 +61,28 @@ class _LeaderboardState extends State<Leaderboard> {
     int rank = 0;
 
     return ListView(
-          padding: const EdgeInsets.symmetric(vertical: 8.0),
-          children: 
-          topTenTrees.map((item) {
-            rank++;
-          //var futureTree = fetchTree(item.get_treeId());
-            return ListTile(
-              leading: CircleAvatar(
-                backgroundColor: const Color.fromARGB(255, 5, 87, 47),
-                child: Text(rank.toString()),
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      children: topTenTrees.map((item) {
+        rank++;
+        //var futureTree = fetchTree(item.get_treeId());
+        return ListTile(
+          leading: CircleAvatar(
+            backgroundColor: const Color.fromARGB(255, 5, 87, 47),
+            child: Text(rank.toString()),
+          ),
+          title: Text("Tree #" + item.treeid.toString()),
+          trailing: Text(item.likes.toString()),
+          onTap: () async {
+            await Navigator.of(context).push(
+              MaterialPageRoute(
+                builder: (context) => TreeInfo(
+                  treeid: item.treeid,
+                ),
               ),
-              title: Text("Tree #" + item.treeid.toString()),
-              trailing: Text(item.likes.toString()),
-              onTap: () async {
-          await Navigator.of(context).push(
-            MaterialPageRoute(
-              builder: (context) => TreeInfo(treeid: item.treeid,
-                
-              ),
-            ),
-      
-          );
-        },
-              
             );
-          }).toList(),
-    
-        
-      
+          },
+        );
+      }).toList(),
     );
-    
   }
-  
-  
 }

--- a/final_project/lib/pages/main_scaffold.dart
+++ b/final_project/lib/pages/main_scaffold.dart
@@ -32,7 +32,7 @@ class _MainScaffoldState extends State<MainScaffold> {
 
   bool inList(TreeObject tree, List list){
     for(var item in list){
-      if(item.get_treeId() == tree.get_treeId()){
+      if(item.treeid == tree.treeid){
         return true;
       }
       else{
@@ -46,7 +46,7 @@ class _MainScaffoldState extends State<MainScaffold> {
   int findDuplicate(TreeObject tr, List<TreeObject> listTr){
     int index = 0;
     for(var t in listTr){
-      if(t.get_treeId() == tr.get_treeId()){
+      if(t.treeid == tr.treeid){
         return index;
       }
       else{
@@ -123,7 +123,7 @@ class _MainScaffoldState extends State<MainScaffold> {
         items: const [
           BottomNavigationBarItem(
               icon: Icon(Icons.leaderboard), label: "Leaderboard"),
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: "Home"),
+          BottomNavigationBarItem(icon: Icon(Icons.map), label: "Map"),
           BottomNavigationBarItem(icon: Icon(Icons.info), label: "About"),
         ],
         currentIndex: pageIndex,


### PR DESCRIPTION
Modified `Leaderboard.dart` to use a PriorityQueue instead of a normal list. By overriding the `compareTo` function in `tree_object.dart`, we can make the leaderboard sorting fully automatic. 

There is some temporary code to show the sorting works that can be removed once likes are contained in firebase or wherever.

