### PR TITLE
Add loading icon when searching so users know something is happening

### DIFF
--- a/final_project/lib/pages/body/map.dart
+++ b/final_project/lib/pages/body/map.dart
@@ -28,6 +28,7 @@ class _MapState extends State<Map> {
   Specialty? selectedSpecialty;
 
   SearchResult? searchResult;
+  bool _isLoading = true;
 
   @override
   void initState() {
@@ -70,6 +71,16 @@ class _MapState extends State<Map> {
                     ],
                   ),
                 ),
+                // Incredibly helpful reference:
+                // https://dartling.dev/displaying-a-loading-overlay-or-progress-hud-in-flutter
+                if (_isLoading)
+                  const Opacity(
+                    opacity: 0.8,
+                    child:
+                        ModalBarrier(dismissible: false, color: Colors.black),
+                  ),
+                if (_isLoading)
+                  const Center(child: CircularProgressIndicator()),
                 Column(
                   children: [
                     buildStyledContainer(


### PR DESCRIPTION
Resolves #47 

When any operation that loads markers on the map is started, the map is grayed out and a spinner is displayed until the markers appear.